### PR TITLE
docs: add GitHub issue and pull request templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,45 @@
+---
+name: Bug Report
+about: Report unexpected behavior or a regression
+title: ""
+labels: bug
+assignees: ""
+---
+
+## AS IS
+
+<!--
+Describe what actually happens.
+Include the exact command you ran and the output you observed.
+-->
+
+**Steps to reproduce:**
+
+1.
+2.
+3.
+
+**Actual output:**
+
+```
+(paste output here)
+```
+
+## TO BE
+
+<!--
+Describe the expected behavior.
+-->
+
+**Expected output:**
+
+```
+(paste expected output here)
+```
+
+## Environment
+
+- prw version: <!-- e.g. 0.1.0 -->
+- Node.js version: <!-- e.g. 20.11.0 -->
+- OS: <!-- e.g. macOS 14, Ubuntu 22.04 -->
+- Package manager: <!-- e.g. pnpm 9, npm 10 -->

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,28 @@
+---
+name: Feature Request
+about: Propose a new feature or UX improvement
+title: ""
+labels: enhancement
+assignees: ""
+---
+
+## AS IS
+
+<!--
+Describe the current behavior or limitation.
+Include relevant code paths or UI output if applicable.
+-->
+
+## TO BE
+
+<!--
+Describe the desired behavior or UX.
+Add concrete examples (CLI output, ASCII diagrams, etc.) to make the goal unambiguous.
+-->
+
+## Implementation Notes
+
+<!--
+Optional: hints on how to implement, affected files, library choices, trade-offs, etc.
+Remove this section if you have no implementation notes.
+-->

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,18 @@
+## What
+
+<!--
+Describe what this PR changes.
+-->
+
+## Why
+
+<!--
+Explain why this change is needed.
+-->
+
+## Ref
+
+<!--
+Related issues, PRs, ADRs, or external resources.
+e.g. Closes #2
+-->


### PR DESCRIPTION

## What

Add GitHub issue templates (feature request and bug report) and a PR template.

## Why

There was no consistent format for issues and PRs. Existing issues follow an `AS IS / TO BE` structure, so formalizing it as a template ensures that future issues and PRs maintain the same clarity.

## Ref

- Based on the format used in issues #2, #3, and #4