### PR TITLE
docs: rewrite README in English and Japanese

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 nyatinte
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.ja.md
+++ b/README.ja.md
@@ -1,0 +1,103 @@
+# @nyatinte/prw
+
+[English](./README.md) | 日本語
+
+`prw` は、pnpm workspace のルートからパッケージとスクリプトを選んで実行するための CLI ツールです。
+
+> [!IMPORTANT]
+> `prw` は意図的に機能を絞っています。
+> workspace 内にすでに定義されている script を選んで実行することだけを扱います。
+> 独自のタスク定義や追加の仕組みは持ち込みません。
+
+## これは何をするツールか
+
+pnpm workspace で、実行したい package と script をルートから選んで実行します。
+使うのは既存の `package.json` scripts だけです。
+
+## インストール
+
+```bash
+npm install -g @nyatinte/prw
+# or
+pnpm add -g @nyatinte/prw
+```
+
+## 使い方
+
+### 1. 引数なしで起動する
+
+```bash
+prw
+```
+
+package を選んで、script を選んで、そのまま実行します。
+workspace root の package も選択できます。
+
+### 2. package を先に指定する
+
+```bash
+prw web
+```
+
+package 名はラフに指定できます。
+完全一致でなくても、名前の一部が合っていれば絞り込めます。
+マッチする package が 1 件なら、そのまま script 選択に進みます。
+複数マッチした場合は package 選択画面が表示されます。
+よく使う package は履歴に基づいて上に表示されます。
+
+### 3. package と script を直接指定する
+
+```bash
+prw @myapp/web dev
+```
+
+package と script が特定できれば、そのまま実行します。
+実行できるのは `package.json` に定義された script だけです。
+よく使う script も履歴に基づいて上に表示されます。
+
+> [!NOTE]
+> package 名を毎回フルで打つ必要はありません。
+> `prw web` のような短い指定でも使えます。
+
+## 実行イメージ
+
+```text
+$ prw
+? Select package
+❯ (root)
+  @myapp/web      apps/web
+  @myapp/api      apps/api
+
+? Select script
+❯ dev
+  build
+  test
+```
+
+## workspace の例
+
+```text
+.
+├─ package.json
+├─ pnpm-workspace.yaml
+├─ apps/
+│  └─ web/
+│     └─ package.json
+└─ packages/
+   ├─ ui/
+   │  └─ package.json
+   └─ config/
+      └─ package.json
+```
+
+このような monorepo で、ルートから `apps/*` や `packages/*` の scripts を選んで実行できます。
+
+## 注意事項
+
+> [!IMPORTANT]
+> `prw` は workspace root で実行してください。
+> カレントディレクトリに `pnpm-workspace.yaml` がない場合は動作しません。
+
+## License
+
+MIT

--- a/README.md
+++ b/README.md
@@ -1,92 +1,102 @@
 # @nyatinte/prw
 
-pnpm workspace で、rootからインタラクティブにパッケージとスクリプトを選んで実行するCLIツール。
+English | [日本語](./README.ja.md)
 
-## インストール
+`prw` is a CLI for selecting a package and running one of its scripts from the root of a pnpm workspace.
+
+> [!IMPORTANT]
+> `prw` is intentionally small.
+> It only runs scripts that already exist in your workspace.
+> It does not add its own task system.
+
+## What It Does
+
+`prw` lets you pick a package and a script from your pnpm workspace root, then runs it.
+It only uses scripts already defined in `package.json`.
+
+## Installation
 
 ```bash
 npm install -g @nyatinte/prw
-# または
+# or
 pnpm add -g @nyatinte/prw
 ```
 
-## 使い方
+## Usage
 
-### モード 1: インタラクティブ選択（引数なし）
+### 1. Start without arguments
 
 ```bash
 prw
-# ↓ パッケージ一覧を表示
-# ❯ (root)          .
-#   @myapp/web      apps/web
-#   @myapp/api      apps/api
-# ↓ スクリプト一覧を表示
-# ❯ dev
-#   build
-#   test
 ```
 
-### モード 2: パッケージ指定（パッケージ名のfuzzy match）
+Pick a package, pick a script, and run it.
+You can also select the workspace root package.
+
+### 2. Pass a package first
 
 ```bash
 prw web
-# @myapp/web が自動選択 → スクリプト選択画面へ
 ```
 
-複数にマッチした場合はパッケージ選択画面が表示されます。
+Package names can be matched loosely.
+You do not need to type the full name every time.
+If only one package matches, `prw` goes straight to script selection.
+If multiple packages match, it shows the package picker.
+Frequently used packages are shown first.
 
-### モード 3: 直接実行（パッケージ + スクリプト指定）
+### 3. Pass both package and script
 
 ```bash
 prw @myapp/web dev
-# 直接実行、UIなし
 ```
 
-## 特徴
+If the package and script are clear, `prw` runs them directly.
+Only scripts defined in `package.json` are runnable.
+Frequently used scripts are shown first.
 
-- 🎯 **インタラクティブ**: fuzzy search で素早くパッケージ・スクリプトを検索
-- 📝 **履歴機能**: よく使うパッケージ・スクリプトは常に上に表示
-- ⚡ **高速**: 軽量なCLI、起動時間最小化
-- 📦 **pnpm対応**: pnpm workspace に完全対応
+> [!NOTE]
+> Short input like `prw web` is enough in many cases.
 
-## デモ
+## Example
 
-```
+```text
 $ prw
-? Select package ›
-❯ @myapp/web      apps/web
+? Select package
+❯ (root)
+  @myapp/web      apps/web
   @myapp/api      apps/api
-  (root)          .
 
-? Select script ›
+? Select script
 ❯ dev
   build
-  type-check
   test
 ```
 
-## ライセンス
+## Workspace Layout
 
-MIT
-
-## リリース運用
-
-このリポジトリは Changesets でリリース管理します。
-
-```bash
-# 変更内容に対する release intent を追加
-pnpm changeset
-
-# pending changeset を package.json / changelog に反映
-pnpm version-packages
+```text
+.
+├─ package.json
+├─ pnpm-workspace.yaml
+├─ apps/
+│  └─ web/
+│     └─ package.json
+└─ packages/
+   ├─ ui/
+   │  └─ package.json
+   └─ config/
+      └─ package.json
 ```
 
-`.github/workflows/release.yml` は `main` への push ごとに pending changeset を
-集約した release PR を作成または更新します。release PR が merge されると、
-同じ workflow から `pnpm release` を実行して npm publish し、GitHub Release も
-自動作成します。
+From the workspace root, `prw` can run scripts from `apps/*` and `packages/*`.
 
-npm への publish は GitHub Actions の Trusted Publishing を前提にしており、
-この workflow には `id-token: write` を付与しています。初回 publish 前に npm 側で
-`nyatinte/prw` と `.github/workflows/release.yml` を trusted publisher として
-関連付けてください。
+## Notes
+
+> [!IMPORTANT]
+> Run `prw` from the workspace root.
+> It expects `pnpm-workspace.yaml` in the current directory.
+
+## License
+
+MIT

--- a/package.json
+++ b/package.json
@@ -4,7 +4,9 @@
   "description": "Interactive pnpm workspace package & script runner",
   "type": "module",
   "main": "./dist/index.mjs",
-  "bin": "./dist/bin.mjs",
+  "bin": {
+    "prw": "./dist/bin.mjs"
+  },
   "scripts": {
     "build": "tsdown",
     "test": "vitest",


### PR DESCRIPTION
## What

- Rewrite the root `README.md` in English and make English the default README
- Add `README.ja.md` as the Japanese version and link the two pages to each other
- Add a `LICENSE` file with the MIT license

## Why

The old README was Japanese-only, mixed user documentation with release workflow notes, and did not reflect the intended bilingual structure.


## Ref

- Template: `.github/pull_request_template.md`
