### PR TITLE
Fix tsdown CLI entry output

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,6 @@
   "version": "0.0.1",
   "description": "Interactive pnpm workspace package & script runner",
   "type": "module",
-  "main": "./dist/index.mjs",
   "bin": {
     "prw": "./dist/bin.mjs"
   },

--- a/tsdown.config.ts
+++ b/tsdown.config.ts
@@ -1,5 +1,7 @@
 import { defineConfig } from "tsdown";
 
 export default defineConfig({
-  entry: ["src/index.ts", "src/bin.ts"],
+  entry: {
+    bin: "src/bin.ts",
+  },
 });


### PR DESCRIPTION
## Summary
- restrict tsdown entry to the CLI bin entry only
- remove the unused package main field for this CLI-only package
- keep the published output aligned with `dist/bin.mjs`

## Verification
- pnpm build
- pnpm test