### PR TITLE
chore: allowbuild lefthook

### DIFF
--- a/package.json
+++ b/package.json
@@ -50,6 +50,11 @@
     "pnpm": "10.30.3"
   },
   "packageManager": "pnpm@10.30.3",
+  "pnpm": {
+    "onlyBuiltDependencies": [
+      "lefthook"
+    ]
+  },
   "devDependencies": {
     "@biomejs/biome": "2.4.0",
     "@changesets/cli": "2.30.0",


### PR DESCRIPTION
## What

Add `lefthook` to `pnpm.onlyBuiltDependencies` in `package.json`.

## Why

This repository runs `lefthook install` in the `prepare` script. When pnpm is configured to allow only selected dependency build scripts, `lefthook` also needs to be explicitly allowed so install flows do not fail.

## Ref

N/A
