### PR TITLE
Migrate typecheck to tsgo

### DIFF
--- a/.changeset/tsgo-typecheck.md
+++ b/.changeset/tsgo-typecheck.md
@@ -1,5 +1,0 @@
----
-"@nyatinte/prw": patch
----
-
-Switch repository type-checking from `tsc --noEmit` to `tsgo`.

--- a/README.ja.md
+++ b/README.ja.md
@@ -22,16 +22,6 @@ npm install -g @nyatinte/prw
 pnpm add -g @nyatinte/prw
 ```
 
-## 開発
-
-このリポジトリでは型チェックに [`tsgo`](https://github.com/microsoft/typescript-go) を使います。
-
-```bash
-pnpm typecheck
-pnpm test run
-pnpm build
-```
-
 ## 使い方
 
 ### 1. 引数なしで起動する

--- a/README.md
+++ b/README.md
@@ -22,16 +22,6 @@ npm install -g @nyatinte/prw
 pnpm add -g @nyatinte/prw
 ```
 
-## Development
-
-This repo uses [`tsgo`](https://github.com/microsoft/typescript-go) for type checking.
-
-```bash
-pnpm typecheck
-pnpm test run
-pnpm build
-```
-
 ## Usage
 
 ### 1. Start without arguments


### PR DESCRIPTION
## What

- add `@typescript/native-preview` and a dedicated `pnpm typecheck` script backed by `tsgo`
- switch CI type checking from `tsc --noEmit` to `pnpm typecheck`
- keep the existing `tsdown` build flow unchanged

## Why

- migrate the repository type-check path to `typescript-go` without widening the change scope beyond the requested tooling update
- make local and CI type checking use the same explicit `tsgo` entrypoint
- avoid changing packaging, docs, or release behavior as part of this migration

## Ref

- [microsoft/typescript-go](https://github.com/microsoft/typescript-go)
