### PR TITLE
Enforce type aliases for object types

### DIFF
--- a/biome.jsonc
+++ b/biome.jsonc
@@ -1,4 +1,16 @@
 {
   "$schema": "./node_modules/@biomejs/biome/configuration_schema.json",
-  "extends": ["ultracite/biome/core"]
+  "extends": ["ultracite/biome/core"],
+  "linter": {
+    "rules": {
+      "style": {
+        "useConsistentTypeDefinitions": {
+          "level": "error",
+          "options": {
+            "style": "type"
+          }
+        }
+      }
+    }
+  }
 }

--- a/src/history.ts
+++ b/src/history.ts
@@ -2,11 +2,11 @@ import { mkdirSync, readFileSync, writeFileSync } from "node:fs";
 import { homedir } from "node:os";
 import { join } from "node:path";
 
-export interface HistoryEntry {
+export type HistoryEntry = {
   package: string;
   script: string;
   timestamp: number;
-}
+};
 
 const HISTORY_DIR = join(homedir(), ".config", "prw");
 const HISTORY_FILE = join(HISTORY_DIR, "history.json");

--- a/src/workspace.ts
+++ b/src/workspace.ts
@@ -13,10 +13,10 @@ export class WorkspaceNotFoundError extends Error {
   }
 }
 
-export interface Package {
+export type Package = {
   readonly dir: string;
   readonly name: string;
-}
+};
 
 export const ROOT_PACKAGE: Package = { name: "(root)", dir: "." };
 


### PR DESCRIPTION
## What

- replace existing exported `interface` declarations with `type` aliases
- add a Biome rule to enforce `type`-style type definitions going forward
- verify the change with `pnpm exec biome check .` and `pnpm test`

## Why

The project was mixing `interface` and `type` notation for similar object-shape definitions. This change aligns the codebase with the preferred `type` style and prevents future drift.

## Ref

- None
