### PR TITLE
fix: use local binaries in pre-commit hook

### DIFF
--- a/lefthook.yml
+++ b/lefthook.yml
@@ -1,6 +1,6 @@
 pre-commit:
   jobs:
-    - run: pnpm exec ultracite fix {staged_files}
+    - run: pnpm fix -- {staged_files}
       glob:
         - "**/*.js"
         - "**/*.jsx"
@@ -10,4 +10,4 @@ pre-commit:
         - "**/*.jsonc"
         - "**/*.css"
       stage_fixed: true
-    - run: pnpm exec knip
+    - run: pnpm knip


### PR DESCRIPTION
## What

Switch the pre-commit hook to use project-local binaries instead of `pnpm dlx`.

- change `pnpm dlx ultracite fix` to `pnpm exec ultracite fix {staged_files}`
- change `pnpm knip` to `pnpm exec knip`

## Why

`pnpm dlx ultracite fix` runs Ultracite from a temporary environment, but Ultracite then tries to spawn `biome` from the project environment. That caused the pre-commit hook to fail with `spawnSync biome ENOENT`.

Using `pnpm exec` keeps the hook on the repository's installed toolchain and avoids the missing-binary failure.

## Ref

- N/A
