### PR TITLE
chore: replace fast-glob and js-yaml

### DIFF
--- a/.changeset/swift-poems-fold.md
+++ b/.changeset/swift-poems-fold.md
@@ -1,0 +1,7 @@
+---
+"@nyatinte/prw": patch
+---
+
+Replace `fast-glob` with `tinyglobby` and `js-yaml` with `yaml`.
+
+Keep workspace package discovery behavior compatible by normalizing matched directory paths.

--- a/package.json
+++ b/package.json
@@ -49,14 +49,13 @@
   },
   "dependencies": {
     "@clack/prompts": "1.1.0",
-    "fast-glob": "3.3.3",
-    "js-yaml": "4.1.1",
-    "picocolors": "1.1.1"
+    "picocolors": "1.1.1",
+    "tinyglobby": "0.2.15",
+    "yaml": "2.8.2"
   },
   "devDependencies": {
     "@biomejs/biome": "2.4.6",
     "@changesets/cli": "2.30.0",
-    "@types/js-yaml": "4.0.9",
     "@types/node": "24.12.0",
     "@typescript/native-preview": "7.0.0-dev.20260314.1",
     "@vitest/coverage-v8": "4.1.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -11,15 +11,15 @@ importers:
       '@clack/prompts':
         specifier: 1.1.0
         version: 1.1.0
-      fast-glob:
-        specifier: 3.3.3
-        version: 3.3.3
-      js-yaml:
-        specifier: 4.1.1
-        version: 4.1.1
       picocolors:
         specifier: 1.1.1
         version: 1.1.1
+      tinyglobby:
+        specifier: 0.2.15
+        version: 0.2.15
+      yaml:
+        specifier: 2.8.2
+        version: 2.8.2
     devDependencies:
       '@biomejs/biome':
         specifier: 2.4.6
@@ -27,9 +27,6 @@ importers:
       '@changesets/cli':
         specifier: 2.30.0
         version: 2.30.0(@types/node@24.12.0)
-      '@types/js-yaml':
-        specifier: 4.0.9
-        version: 4.0.9
       '@types/node':
         specifier: 24.12.0
         version: 24.12.0
@@ -952,9 +949,6 @@ packages:
 
   '@types/estree@1.0.8':
     resolution: {integrity: sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==}
-
-  '@types/js-yaml@4.0.9':
-    resolution: {integrity: sha512-k4MGaQl5TGo/iipqb2UDG2UwjXziSWkh0uysQelTlJpX1qGlpUZYm8PnO4DxG1qBomtJUdYJ6qR6xdIah10JLg==}
 
   '@types/jsesc@2.5.1':
     resolution: {integrity: sha512-9VN+6yxLOPLOav+7PwjZbxiID2bVaeq0ED4qSQmdQTdjnXJSaCVKTR58t15oqH1H5t8Ng2ZX1SabJVoN9Q34bw==}
@@ -2503,8 +2497,6 @@ snapshots:
   '@types/deep-eql@4.0.2': {}
 
   '@types/estree@1.0.8': {}
-
-  '@types/js-yaml@4.0.9': {}
 
   '@types/jsesc@2.5.1': {}
 

--- a/src/workspace.ts
+++ b/src/workspace.ts
@@ -1,10 +1,11 @@
 import { existsSync, readFileSync } from "node:fs";
 import { readFile } from "node:fs/promises";
 import { join, resolve } from "node:path";
-import glob from "fast-glob";
-import YAML from "js-yaml";
+import { glob } from "tinyglobby";
+import { parse } from "yaml";
 
 const WORKSPACE_CONFIG_FILE = "pnpm-workspace.yaml";
+const TRAILING_PATH_SEPARATOR_PATTERN = /[\\/]+$/;
 
 export class WorkspaceNotFoundError extends Error {
   constructor(message: string) {
@@ -40,7 +41,7 @@ export async function getPackages(root: string): Promise<Package[]> {
     join(root, WORKSPACE_CONFIG_FILE),
     "utf-8"
   );
-  const config = (YAML.load(workspaceConfig) ?? {}) as { packages?: string[] };
+  const config = (parse(workspaceConfig) ?? {}) as { packages?: string[] };
 
   const packages: Package[] = [ROOT_PACKAGE];
 
@@ -55,7 +56,8 @@ export async function getPackages(root: string): Promise<Package[]> {
   });
 
   const results = await Promise.all(
-    dirs.map(async (dir) => {
+    dirs.map(async (rawDir) => {
+      const dir = rawDir.replace(TRAILING_PATH_SEPARATOR_PATTERN, "");
       try {
         const pkgJson = JSON.parse(
           await readFile(join(root, dir, "package.json"), "utf-8")


### PR DESCRIPTION
## What

Replace `fast-glob` with `tinyglobby` and `js-yaml` with `yaml`.

This also normalizes matched directory paths so workspace package discovery keeps the same behavior after the glob implementation change.

## Why

These dependencies were flagged as having suggested replacements by e18e:
- [fast-glob replacement guidance](https://e18e.dev/docs/replacements/fast-glob.html)
- [js-yaml replacement guidance](https://e18e.dev/docs/replacements/js-yaml.html)

The runtime usage in this package is limited to workspace glob expansion and `pnpm-workspace.yaml` parsing, so the replacement is low-risk and reduces reliance on the flagged packages.

## Ref

- [fast-glob replacement guidance](https://e18e.dev/docs/replacements/fast-glob.html)
- [js-yaml replacement guidance](https://e18e.dev/docs/replacements/js-yaml.html)
