### PR TITLE
Add Renovate configuration

### DIFF
--- a/.changeset/fair-horses-lay.md
+++ b/.changeset/fair-horses-lay.md
@@ -1,5 +1,0 @@
----
-"@nyatinte/prw": patch
----
-
-Add a Renovate configuration that ignores example fixtures and automerges aged non-major dependency updates.


### PR DESCRIPTION
## Summary
- add Renovate config in `renovate.json5`
- ignore all dependency files under `example/**`
- automerge non-major updates after 1 day once checks are no longer pending

## Testing
- not run (configuration-only change)