### PR TITLE
docs: add README badges

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -4,7 +4,7 @@
 
 [![CI](https://github.com/nyatinte/prw/actions/workflows/ci.yml/badge.svg)](https://github.com/nyatinte/prw/actions/workflows/ci.yml)
 [![npm downloads](https://img.shields.io/npm/dm/%40nyatinte%2Fprw)](https://npmx.dev/package/@nyatinte/prw#downloads)
-[![pnpm](https://img.shields.io/badge/pnpm-10.30.3-F69220?logo=pnpm&logoColor=white)](https://pnpm.io/)
+[![pnpm](https://img.shields.io/badge/pnpm-F69220?logo=pnpm&logoColor=white)](https://pnpm.io/)
 
 `prw` は、pnpm workspace のルートからパッケージとスクリプトを選んで実行するための CLI ツールです。
 

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ English | [日本語](./README.ja.md)
 
 [![CI](https://github.com/nyatinte/prw/actions/workflows/ci.yml/badge.svg)](https://github.com/nyatinte/prw/actions/workflows/ci.yml)
 [![npm downloads](https://img.shields.io/npm/dm/%40nyatinte%2Fprw)](https://npmx.dev/package/@nyatinte/prw#downloads)
-[![pnpm](https://img.shields.io/badge/pnpm-10.30.3-F69220?logo=pnpm&logoColor=white)](https://pnpm.io/)
+[![pnpm](https://img.shields.io/badge/pnpm-F69220?logo=pnpm&logoColor=white)](https://pnpm.io/)
 
 `prw` is a CLI for selecting a package and running one of its scripts from the root of a pnpm workspace.
 


### PR DESCRIPTION
## What
Add a small badge row to the English and Japanese README top sections.

## Why
Make the repository front page easier to scan with project status and package signals.

## Ref
N/A